### PR TITLE
fix: remove node globals

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -1,6 +1,6 @@
 const { Buffer } = require('buffer')
 const BufferList = require('bl/BufferList')
-const { S_IFMT, S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK } = require('fs-constants')
+const { S_IFMT, S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK } = require('iso-constants')
 const concat = require('it-concat')
 const Headers = require('./pack-headers')
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "bl": "^4.0.0",
     "buffer": "^5.4.3",
-    "fs-constants": "^1.0.0",
+    "iso-constants": "^0.1.2",
     "it-concat": "^1.0.0",
     "it-reader": "^2.0.0",
     "p-defer": "^3.0.0"


### PR DESCRIPTION
fs-contants relies on node constants global to exist and be injected by browser bundlers (which is super outdated).

iso-constants removes the need for the bundler to inject outdated packages and also auto updates the constants to the node version been used.

related to https://github.com/ipfs/js-ipfs/issues/2924